### PR TITLE
Update findup sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
-  - "0.10"
+  - "6"
+  - "5"
+  - "4"
   - "0.12"
-  - "iojs"
+  - "0.10"
 before_install:
   - npm update -g npm
 matrix:
   fast_finish: true
+  allow_failures:
+    - node_js: "0.10"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "extend": "^3.0.0",
-    "findup-sync": "^0.3.0",
+    "findup-sync": "^0.4.2",
     "flagged-respawn": "^0.3.2",
     "rechoir": "^0.6.2",
     "resolve": "^1.1.7"

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,11 @@ describe('Liftoff', function () {
       expect(app.buildEnvironment({cwd:'./'}).configPath).to.equal(null);
     });
 
+    it('should find case sensitive configPath', function () {
+      var expected = path.resolve(__dirname, 'fixtures', 'case', (process.platform === 'linux' ? 'Mochafile.js' : 'mochafile.js'));
+      expect(app.buildEnvironment({cwd:path.join(__dirname, 'fixtures', 'case')}).configPath).to.equal(expected);
+    });
+
     it('should find module in the directory next to config', function () {
       expect(app.buildEnvironment().modulePath).to.equal(path.resolve('node_modules/mocha/index.js'));
     });

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,8 @@ describe('Liftoff', function () {
       var test = new Liftoff({name:'chai'});
       var cwd = 'explicit/cwd';
       var spy = sinon.spy(resolve, 'sync');
+      // NODE_PATH might be defined.
+      delete process.env.NODE_PATH;
       test.buildEnvironment({cwd:cwd});
       expect(spy.calledWith('chai', {basedir:path.join(process.cwd(),cwd),paths:[]})).to.be.true;
       spy.restore();


### PR DESCRIPTION
This PR does the following:
 - updates the findup-sync dependency
 - updates .travis.yml to include more node versions and both osx and linux platforms
 - adds a test for finding the config path on a case sensitive file system.

Let me know if there's anything else I can do for this.