### PR TITLE
Add beforeRequire event

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,14 +446,25 @@ A function called after your application is executed.  When invoked, `this` will
 
 ### events
 
+#### beforeRequire(name)
+
+Emitted before a module is pre-load. (But for only a module which is specified by `opts.require`.)
+
+```js
+var Hacker = new Liftoff({name:'hacker', require:'coffee-script'});
+Hacker.on('beforeRequire', function (name) {
+  console.log('Requiring external module: '+name+'...');
+});
+```
+
 #### require(name, module)
 
-Emitted when a module is pre-loaded.
+Emitted when a module has been pre-loaded.
 
 ```js
 var Hacker = new Liftoff({name:'hacker'});
 Hacker.on('require', function (name, module) {
-  console.log('Requiring external module: '+name+'...');
+  console.log('Required external module: '+name+'...');
   // automatically register coffee-script extensions
   if (name === 'coffee-script') {
     module.register();

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ util.inherits(Liftoff, EE);
 
 Liftoff.prototype.requireLocal = function(module, basedir) {
   try {
+    this.emit('beforeRequire', module);
     var result = require(resolve.sync(module, { basedir: basedir }));
     this.emit('require', module, result);
     return result;

--- a/test/index.js
+++ b/test/index.js
@@ -347,20 +347,32 @@ describe('Liftoff', function() {
       }
     });
 
-    it('should emit `require` with the name of the module and the required module', function(done) {
+    it('should emit `beforeRequire` and `require` with the name of the module and the required module', function(done) {
       var requireTest = new Liftoff({ name: 'require' });
+      var isEmittedBeforeRequired = false;
+      requireTest.on('beforeRequire', function(name) {
+        expect(name).to.equal('mocha');
+        isEmittedBeforeRequired = true;
+      });
       requireTest.on('require', function(name, module) {
         expect(name).to.equal('mocha');
         expect(module).to.equal(require('mocha'));
+        expect(isEmittedBeforeRequired).to.equal(true);
         done();
       });
       requireTest.requireLocal('mocha', __dirname);
     });
 
-    it('should emit `requireFail` with an error if a module can\'t be found.', function(done) {
+    it('should emit `beforeRequire` and `requireFail` with an error if a module can\'t be found.', function(done) {
       var requireFailTest = new Liftoff({ name: 'requireFail' });
+      var isEmittedBeforeRequired = false;
+      requireFailTest.on('beforeRequire', function(name) {
+        expect(name).to.equal('badmodule');
+        isEmittedBeforeRequired = true;
+      });
       requireFailTest.on('requireFail', function(name) {
         expect(name).to.equal('badmodule');
+        expect(isEmittedBeforeRequired).to.equal(true);
         done();
       });
       requireFailTest.requireLocal('badmodule', __dirname);


### PR DESCRIPTION
This is a pr for the issue #53.

This pr makes liftoff emit `beforeRequire` event, but for only a module which is specified by `opts.require`.