### PR TITLE
Change timing of requiring a loader for config to fix the issue #90

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const silentRequire = require('./lib/silent_require');
 const buildConfigName = require('./lib/build_config_name');
 const registerLoader = require('./lib/register_loader');
 const getNodeFlags = require('./lib/get_node_flags');
+const prepareConfig = require('./lib/prepare_config');
 
 
 function Liftoff (opts) {
@@ -115,19 +116,8 @@ Liftoff.prototype.buildEnvironment = function (opts) {
     }
   }
 
-  // load any modules which were requested to be required
-  if (preload.length) {
-    // unique results first
-    preload.filter(function (value, index, self) {
-      return self.indexOf(value) === index;
-    }).forEach(function (dep) {
-      this.requireLocal(dep, findCwd(opts));
-    }, this);
-  }
-
   var exts = this.extensions;
   var eventEmitter = this;
-  registerLoader(eventEmitter, exts, configPath, cwd);
 
   var configFiles = {};
   if (isPlainObject(this.configFiles)) {
@@ -200,12 +190,11 @@ Liftoff.prototype.launch = function (opts, fn) {
         this.emit('respawn', execArgv, child);
       }
       if (ready) {
+        prepareConfig.call(this, env, opts);
         fn.call(this, env, argv);
       }
     }
   }.bind(this));
 };
-
-
 
 module.exports = Liftoff;

--- a/lib/prepare_config.js
+++ b/lib/prepare_config.js
@@ -1,0 +1,19 @@
+const registerLoader = require('./register_loader');
+const findCwd = require('./find_cwd');
+
+function prepareConfig(env, opts) {
+  const self = this;
+
+  const basedir = findCwd(opts);
+  env.require.filter(toUnique).forEach(function(module) {
+    self.requireLocal(module, basedir);
+  });
+
+  registerLoader(self, self.extensions, env.configPath, env.cwd);
+}
+
+function toUnique(elem, index, array) {
+  return array.indexOf(elem) === index;
+}
+
+module.exports = prepareConfig;

--- a/test/fixtures/respawn_and_require.js
+++ b/test/fixtures/respawn_and_require.js
@@ -1,0 +1,21 @@
+const Liftoff = require('../..');
+
+const Test = new Liftoff({
+  name: 'test',
+  v8flags: ['--harmony'],
+});
+
+Test.on('respawn', function(flags, proc) {
+  console.log('saw respawn', flags);
+});
+
+Test.on('require', function(name) {
+  console.log('require', name);
+});
+
+Test.launch({
+  require: 'coffeescript/register',
+  forcedFlags: ['--lazy'],
+}, function(env, argv) {
+  console.log('execute');
+});


### PR DESCRIPTION
Preloading modules specified by `opts.require` and requiring a loader for config should move after respawning and ready to run a callback of `launch` to fix the issue #90.