### PR TITLE
Don't emit 'requireFail' when one of loaders succeeded.

### DIFF
--- a/lib/register_loader.js
+++ b/lib/register_loader.js
@@ -8,17 +8,17 @@ module.exports = function(eventEmitter, extensions, configPath, cwd) {
   }
 
   var autoloads = rechoir.prepare(extensions, configPath, cwd, true);
-  if (autoloads instanceof Error) {
-    autoloads = autoloads.failures;
+  if (autoloads instanceof Error) { // Only errors
+    autoloads.failures.forEach(function(failed) {
+      eventEmitter.emit('requireFail', failed.moduleName, failed.error);
+    });
+    return;
   }
 
-  if (Array.isArray(autoloads)) {
-    autoloads.forEach(function (attempt) {
-      if (attempt.error) {
-        eventEmitter.emit('requireFail', attempt.moduleName, attempt.error);
-      } else {
-        eventEmitter.emit('require', attempt.moduleName, attempt.module);
-      }
-    });
+  if (!Array.isArray(autoloads)) { // Already required or no config.
+    return;
   }
+
+  var succeeded = autoloads[autoloads.length - 1];
+  eventEmitter.emit('require', succeeded.moduleName, succeeded.module);
 };

--- a/test/fixtures/register_loader/require-conf.js
+++ b/test/fixtures/register_loader/require-conf.js
@@ -1,0 +1,10 @@
+(function() {
+
+const path = require('path');
+
+require.extensions['.conf'] = function(module, filepath) {
+  module.loaded = true;
+  module.exports = 'Load ' + path.basename(filepath) + ' by require-conf';
+};
+
+}());


### PR DESCRIPTION
Because I think just `'require'` event is enough when one of loaders succeeded.