### PR TITLE
Bump 'extend' Dependency to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cover": "nyc --reporter=lcov --reporter=text-summary npm test"
   },
   "dependencies": {
-    "extend": "^3.0.0",
+    "extend": "~3.0.2",
     "findup-sync": "^3.0.0",
     "fined": "^1.0.1",
     "flagged-respawn": "^1.0.0",


### PR DESCRIPTION
A security vulnerability alert for 'extend' was issued for versions >= 3.0.0, < 3.0.2. The vulnerability allows arbitrary properties to be attached onto the Object prototype. This pull request addresses this by bumping the version number of 'extend' to 3.0.2.

## CVE Details:
**CVE ID**: CVE-2018-16492
**Vulnerable Versions**: >= 3.0.0, < 3.0.2
**Pactched Version**: 3.0.2
**Description**:
A prototype pollution vulnerability was found that allows an attacker to inject arbitrary properties onto Object.prototype.