### PR TITLE
Change timing of completion to enable to configure its error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ Liftoff.prototype.buildEnvironment = function(opts) {
   return {
     cwd: cwd,
     preload: preload,
+    completion: opts.completion,
     configNameSearch: configNameSearch,
     configPath: configPath,
     configBase: configBase,
@@ -164,17 +165,17 @@ Liftoff.prototype.prepare = function(opts, fn) {
 
   process.title = this.processTitle;
 
-  var completion = opts.completion;
-  if (completion && this.completions) {
-    return this.completions(completion);
-  }
-
   var env = this.buildEnvironment(opts);
 
   fn.call(this, env);
 };
 
 Liftoff.prototype.execute = function(env, forcedFlags, fn) {
+  var completion = env.completion;
+  if (completion && this.completions) {
+    return this.completions(completion);
+  }
+
   if (typeof forcedFlags === 'function') {
     fn = forcedFlags;
     forcedFlags = undefined;

--- a/test/index.js
+++ b/test/index.js
@@ -132,16 +132,6 @@ describe('Liftoff', function() {
       expect(process.title).to.equal(app.moduleName);
     });
 
-    it('should return early if completions are available and requested', function(done) {
-      var test = new Liftoff({
-        name: 'whatever',
-        completions: function() {
-          done();
-        },
-      });
-      test.prepare({ completion: true }, function() {});
-    });
-
     it('should call prepare with liftoff instance as context', function(done) {
       app.prepare({}, function() {
         expect(this).to.equal(app);
@@ -177,6 +167,18 @@ describe('Liftoff', function() {
       expect(function() {
         app.execute({});
       }).to.throw();
+    });
+
+    it('should return early if completions are available and requested', function(done) {
+      var test = new Liftoff({
+        name: 'whatever',
+        completions: function() {
+          done();
+        },
+      });
+      test.prepare({ completion: true }, function(env) {
+        test.execute(env);
+      });
     });
 
     it('should skip respawning if process.argv has no values from v8flags in it', function(done) {


### PR DESCRIPTION
This pr moves completion into `execute` method, because the current timing is before loading config files.

This modification is needed for [gulp-cli#161](https://github.com/gulpjs/gulp-cli/pull/161).