### PR TITLE
NONBREAKING: Uplift findup-sync to 4.0.0 to fix prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "extend": "^3.0.0",
-    "findup-sync": "^3.0.0",
+    "findup-sync": "^4.0.0",
     "fined": "^1.0.1",
     "flagged-respawn": "^1.0.0",
     "is-plain-object": "^2.0.4",


### PR DESCRIPTION
Hi @tkellen / @phated 

findup-sync 3.0.0 has a Prototype Pollution vulnerability that is fixed in version 4.0.0

js-liftoff is a dependency of Knex DB.  We're using this in multiple production projects in a commercial environment.  Please can you expedite this pull request so that w can then fix the vulnerability in Knex.

I have tested this as a non-breaking fix.

Happy to answer any questions