### PR TITLE
Deprecate node version <= 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
 node_js:
+  - node
   - "10"
   - "8"
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true
 script: if [ $(echo "${TRAVIS_NODE_VERSION}" | cut -d'.' -f1) -ge 6 ]; then


### PR DESCRIPTION
See issue #110 - deprecate node versions <= 6 to support uplift of dependencies that use the object spread operator