### PR TITLE
Drop old node support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
 node_js:
+  - "14"
+  - "12"
   - "10"
-  - "8"
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true
 script: if [ $(echo "${TRAVIS_NODE_VERSION}" | cut -d'.' -f1) -ge 6 ]; then

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "dependencies": {
     "extend": "^3.0.0",
-    "findup-sync": "^3.0.0",
+    "findup-sync": "^4.0.0",
     "fined": "^1.0.1",
     "flagged-respawn": "^1.0.0",
-    "is-plain-object": "^2.0.4",
+    "is-plain-object": "^3.0.0",
     "object.map": "^1.0.0",
     "rechoir": "^0.7.0",
     "resolve": "^1.1.7"


### PR DESCRIPTION
Ref https://github.com/gulpjs/findup-sync/releases/tag/v4.0.0

The new version of findup-sync depends on new small micromatch.
Would be good to get rid from many node modules.

[knex](http://knexjs.org/) depends on this project.